### PR TITLE
Recursion for MAC_MC code so it doesn't consume hyphens

### DIFF
--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -25,7 +25,7 @@ SUBPHRASE = re.compile(r'([:.;?!\-\—][ ])(%s)' % SMALL)
 APOS_SECOND = re.compile(r"^[dol]{1}['‘]{1}[a-z]+(?:['s]{2})?$", re.I)
 ALL_CAPS = re.compile(r'^[A-Z\s\d%s]+$' % PUNCT)
 UC_INITIALS = re.compile(r"^(?:[A-Z]{1}\.{1}|[A-Z]{1}\.{1}[A-Z]{1})+$")
-MAC_MC = re.compile(r"^([Mm]c)(\w.+)")
+MAC_MC = re.compile(r"^([Mm]c|MC)(\w.+)")
 
 
 def set_small_word_list(small=SMALL):
@@ -76,17 +76,18 @@ def titlecase(text, callback=None):
                     word = word[0].upper() + word[1] + word[2].upper() + word[3:]
                 tc_line.append(word)
                 continue
+
+            match = MAC_MC.match(word)
+            if match:
+                tc_line.append("%s%s" % (match.group(1).capitalize(),
+                                         titlecase(match.group(2),callback)))
+                continue
+
             if INLINE_PERIOD.search(word) or (not all_caps and UC_ELSEWHERE.match(word)):
                 tc_line.append(word)
                 continue
             if SMALL_WORDS.match(word):
                 tc_line.append(word.lower())
-                continue
-
-            match = MAC_MC.match(word)
-            if match:
-                tc_line.append("%s%s" % (match.group(1).capitalize(),
-                                         match.group(2).capitalize()))
                 continue
 
             if "/" in word and "//" not in word:

--- a/titlecase/tests.py
+++ b/titlecase/tests.py
@@ -223,6 +223,10 @@ TEST_DATA = (
     (
         "Mcoblon, spivak, mcclelland, mcmaier, & mcneustadt",
         "McOblon, Spivak, McClelland, McMaier, & McNeustadt",
+    ),
+    (
+        "mcfoo-bar, MCFOO-BAR, McFoo-bar, McFoo-Bar, mcfoo-mcbar, foo-mcbar",
+        "McFoo-Bar, McFoo-Bar, McFoo-Bar, McFoo-Bar, McFoo-McBar, Foo-McBar",
     )
 )
 


### PR DESCRIPTION
The code using the MAC_MC pattern was consuming the entire word which prevented proper casing of hyphenated names in the all-lower and all-upper input cases.

Original behavior:
mcfoo-bar -> McFoo-bar
MCFOO-BAR -> Mcfoo-Bar
McFoo-bar -> McFoo-bar
McFoo-Bar -> McFoo-Bar

Adding recursion fixed the first case.  The second case is sensitive to the status of all_caps.  To make that word work regardless of all_caps (in the line) required the MAC_MC code to be moved before the 'if...not all_caps' test. Surprisingly, this broke no tests, but it did change the behavior of the third case, now "fixing" it to McFoo-Bar also.  This is at least consistent with other hyphenated word behavior.

The final change was to make MAC_MC match 'MC' as well as 'Mc' and 'mc'.  Still don't want it to match 'mC' which presumably would be an input that should be preserved.