### PR TITLE
Add fancy double quote to punctuation

### DIFF
--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -17,7 +17,7 @@ __all__ = ['titlecase']
 __version__ = '0.12.0'
 
 SMALL = 'a|an|and|as|at|but|by|en|for|if|in|of|on|or|the|to|v\.?|via|vs\.?'
-PUNCT = r"""!"#$%&'‘()*+,\-–‒—―./:;?@[\\\]_`{|}~"""
+PUNCT = r"""!"“#$%&'‘()*+,\-–‒—―./:;?@[\\\]_`{|}~"""
 
 SMALL_WORDS = re.compile(r'^(%s)$' % SMALL, re.I)
 INLINE_PERIOD = re.compile(r'[a-z][.][a-z]', re.I)

--- a/titlecase/tests.py
+++ b/titlecase/tests.py
@@ -259,7 +259,11 @@ TEST_DATA = (
     (
         "‘QUOTE’ A GREAT",
         "‘Quote’ a Great",
-    )
+    ),
+    (
+        "“YOUNG AND RESTLESS”",
+        "“Young and Restless”",
+    ),
 )
 
 


### PR DESCRIPTION
This allows “ in text to be capitalised.