### PR TITLE
Add default abbreviations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Command Line Usage
 
 Titlecase also provides a command line utility ``titlecase``:
 
-.. code-block:: python
+::
 
     $ titlecase make me a title
     Make Me a Title
@@ -85,6 +85,17 @@ Titlecase also provides a command line utility ``titlecase``:
     Can Pipe and/or Whatever Else
     # Or read/write files:
     $ titlecase -f infile -o outfile
+
+In addition, commonly used acronyms can be kept in a local file
+at `~/.titlecase.txt`. This file contains one acronym per line.
+The acronym will be maintained in the title as it is provided.
+Once there is e.g. one line saying `TCP`, then it will be automatically
+used when used from the command line.
+
+::
+
+    $ titlecase I LOVE TCP
+    I Love TCP
 
 
 Limitations
@@ -100,4 +111,4 @@ there is basic support for Unicode characters, such that something like
 not be handled correctly.
 
 If anyone has concrete solutions to improve these or other shortcomings of the
-libraries, pull requests are very welcome!
+library, pull requests are very welcome!

--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -62,14 +62,15 @@ def set_small_word_list(small=SMALL):
     SUBPHRASE = regex.compile(r'([:.;?!][ ])(%s)' % small)
 
 
-def retrieve_default_abbreviations():
+def retrieve_abbreviations(path_to_config=None):
     """
     This function checks for a default list of abbreviations which need to 
     remain as they are (e.g. uppercase only or mixed case).
     The file is retrieved from ~/.titlecase.txt (platform independent)
     """
     logger = logging.getLogger(__name__)
-    path_to_config = pathlib.Path.home() / ".titlecase.txt"
+    if path_to_config is None:
+        path_to_config = pathlib.Path.home() / ".titlecase.txt"
     if not os.path.isfile(path_to_config):
         logger.debug('No config file found at ' + str(path_to_config))
         return lambda word, **kwargs : None
@@ -239,4 +240,4 @@ def cmd():
             in_string = ifile.read()
 
     with ofile:
-        ofile.write(titlecase(in_string, callback=retrieve_default_abbreviations()))
+        ofile.write(titlecase(in_string, callback=retrieve_abbreviations()))

--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -71,7 +71,7 @@ def create_wordlist_filter(path_to_config=None):
     """
     if path_to_config is None:
         path_to_config = pathlib.Path.home() / ".titlecase.txt"
-    if not os.path.isfile(path_to_config):
+    if not os.path.isfile(str(path_to_config)):
         logger.debug('No config file found at ' + str(path_to_config))
         return lambda word, **kwargs : None
     with open(str(path_to_config)) as f:

--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -11,7 +11,6 @@ import argparse
 import logging
 logger = logging.getLogger(__name__)
 import os
-import pathlib
 import re
 import string
 import sys
@@ -70,7 +69,7 @@ def create_wordlist_filter(path_to_config=None):
     The file is retrieved from ~/.titlecase.txt (platform independent)
     """
     if path_to_config is None:
-        path_to_config = pathlib.Path.home() / ".titlecase.txt"
+        path_to_config = os.path.join(os.path.expanduser('~'), ".titlecase.txt")
     if not os.path.isfile(str(path_to_config)):
         logger.debug('No config file found at ' + str(path_to_config))
         return lambda word, **kwargs : None

--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -7,8 +7,6 @@ Python version by Stuart Colville http://muffinresearch.co.uk
 License: http://www.opensource.org/licenses/mit-license.php
 """
 
-from __future__ import unicode_literals
-
 import argparse
 import string
 import sys
@@ -36,13 +34,8 @@ MAC_MC = regex.compile(r"^([Mm]c|MC)(\w.+)")
 class Immutable(object):
     pass
 
-
-text_type = unicode if sys.version_info < (3,) else str
-
-
-class ImmutableString(text_type, Immutable):
+class ImmutableString(str, Immutable):
     pass
-
 
 class ImmutableBytes(bytes, Immutable):
     pass

--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -8,11 +8,12 @@ License: http://www.opensource.org/licenses/mit-license.php
 """
 
 import argparse
-import string
-import sys
+import logging
 import os
 import pathlib
-import logging
+import re
+import string
+import sys
 
 import regex
 

--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -214,6 +214,8 @@ def cmd():
             help='File to read from to titlecase')
     parser.add_argument('-o', '--output-file',
             help='File to write titlecased output to')
+    parser.add_argument('-w', '--wordlist',
+            help='Wordlist for acronyms')
 
     args = parser.parse_args()
 
@@ -240,4 +242,7 @@ def cmd():
             in_string = ifile.read()
 
     with ofile:
-        ofile.write(titlecase(in_string, callback=retrieve_abbreviations()))
+        if args.wordlist is None:
+            ofile.write(titlecase(in_string, callback=retrieve_abbreviations()))
+        else:
+            ofile.write(titlecase(in_string, callback=retrieve_abbreviations(args.wordlist)))

--- a/titlecase/tests.py
+++ b/titlecase/tests.py
@@ -7,6 +7,7 @@ from __future__ import print_function, unicode_literals
 
 import os
 import sys
+import tempfile
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../'))
 
 from titlecase import titlecase, set_small_word_list
@@ -351,6 +352,18 @@ def test_set_small_word_list():
     assert titlecase('playing the game "words with friends"') == 'Playing the Game "Words With Friends"'
     set_small_word_list('a|an|the|with')
     assert titlecase('playing the game "words with friends"') == 'Playing the Game "Words with Friends"'
+
+
+def test_custom_abbreviations():
+    with tempfile.NamedTemporaryFile(mode='w') as f:
+        f.write('UDP\nPPPoE\n')
+        f.flush()
+        # This works without a wordlist, because it begins mixed case
+        assert titlecase('sending UDP packets over PPPoE works great') == 'Sending UDP Packets Over PPPoE Works Great'
+        # Without a wordlist, this will do the "wrong" thing for the context
+        assert titlecase('SENDING UDP PACKETS OVER PPPOE WORKS GREAT') == 'Sending Udp Packets Over Pppoe Works Great'
+        # A wordlist can provide custom acronyms
+        assert titlecase('sending UDP packets over PPPoE works great', wordlist_file=f.name) == 'Sending UDP Packets Over PPPoE Works Great'
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34, py35
+envlist = py34, py35, py36, py37, py38
 # Doesn't seem to work on jython currently; some unicode issue
 # pypy breaks on Travis, something from a pulled dep: https://travis-ci.org/ppannuto/python-titlecase/jobs/308106681
 


### PR DESCRIPTION
The text file in the home directory contains one acronym per line. The style (capitals only, mixed, ...) is maintained.