### PR TITLE
Terms with only consonants should be ALL CAPS

### DIFF
--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -10,6 +10,7 @@ License: http://www.opensource.org/licenses/mit-license.php
 from __future__ import unicode_literals
 
 import argparse
+import string
 import sys
 
 import regex
@@ -135,6 +136,17 @@ def titlecase(text, callback=None, small_first_last=True):
 
             if all_caps:
                 word = word.lower()
+
+
+            # A term with all consonants should be considered an acronym.  But if it's
+            # too short (like "St", don't apply this)
+            CONSONANTS = ''.join(set(string.ascii_lowercase)
+                                 - {'a', 'e', 'i', 'o', 'u', 'y'})
+            is_all_consonants = regex.search('\A[' + CONSONANTS + ']+\Z', word,
+                                             flags=regex.IGNORECASE)
+            if is_all_consonants and len(word) > 2:
+                tc_line.append(word.upper())
+                continue
 
             # Just a normal word that needs to be capitalized
             tc_line.append(CAPFIRST.sub(lambda m: m.group(0).upper(), word))

--- a/titlecase/tests.py
+++ b/titlecase/tests.py
@@ -11,6 +11,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../'))
 
 from titlecase import titlecase, set_small_word_list
 
+
+# (executed by `test_input_output` below)
 TEST_DATA = (
     (
         "",
@@ -43,6 +45,10 @@ TEST_DATA = (
     (
         "Apple deal with AT&T falls through",
         "Apple Deal With AT&T Falls Through"
+    ),
+    (
+        "Words with all consonants like cnn are acronyms",
+        "Words With All Consonants Like CNN Are Acronyms"
     ),
     (
         "this v that",
@@ -333,7 +339,9 @@ def test_callback():
         if word.upper() in ('TCP', 'UDP'):
             return word.upper()
     s = 'a simple tcp and udp wrapper'
-    assert titlecase(s) == 'A Simple Tcp and Udp Wrapper'
+    # Note: this library is able to guess that all-consonant words are acronyms, so TCP
+    # works naturally, but others will require the custom list
+    assert titlecase(s) == 'A Simple TCP and Udp Wrapper'
     assert titlecase(s, callback=abbreviation) == 'A Simple TCP and UDP Wrapper'
     assert titlecase(s.upper(), callback=abbreviation) == 'A Simple TCP and UDP Wrapper'
     assert titlecase(u'crème brûlée', callback=lambda x, **kw: x.upper()) == u'CRÈME BRÛLÉE'


### PR DESCRIPTION
Thought this heuristic might be a useful addition...