### PR TITLE
setup.py: Read version from __init__.py to avoid importing the module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,22 @@ import sys
 
 from setuptools import setup, find_packages
 
-def readme():
-    with open('README.rst') as f:
+def read_file(path):
+    with open(path) as f:
         return f.read()
 
-from titlecase import __version__
+def read_version(path):
+    for line in read_file(path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError('No version string found')
 
 setup(name='titlecase',
-    version=__version__,
+    version=read_version('titlecase/__init__.py'),
     description="Python Port of John Gruber's titlecase.pl",
-    long_description=readme(),
+    long_description=read_file('README.rst'),
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
The `titlecase` import in `setup.py` happens before the `setup()` call
is executed, and therefore, none of the modules specified in `setup_requires`
(or `install_requires`, for that matter) are loaded at that moment,
causing the import to fail with `ModuleNotFoundError` for the `regex`
import in `__init__.py`.

Following the first recommendation from the ‘[Single-sourcing the
package version][ugss]’ section of the [Python Packaging User Guide][ug], in this
commit we switch to reading the version string from the `__init__.py`
file instead of having to import the module just for the version string.

[ugss]: https://packaging.python.org/guides/single-sourcing-package-version/
[ug]: https://packaging.python.org/

Fixes #50, #52.