### PR TITLE
setup.py: Read version from __init__.py to avoid importing the module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,24 @@ import sys
 
 from setuptools import setup, find_packages
 
-def readme():
-    with open('README.rst') as f:
+def read_file(rel_path):
+    abs_dir_path = os.path.abspath(os.path.dirname(__file__))
+    abs_path = os.path.join(abs_dir_path, rel_path)
+    with open(abs_path) as f:
         return f.read()
 
-from titlecase import __version__
+def read_version(rel_path):
+    for line in read_file(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError('No version string found')
 
 setup(name='titlecase',
-    version=__version__,
+    version=read_version('titlecase/__init__.py'),
     description="Python Port of John Gruber's titlecase.pl",
-    long_description=readme(),
+    long_description=read_file('README.rst'),
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
The module import happens before setup() is executed, and therefore,
none of the modules specified in 'setup_requires' (or 'install_requires',
for that matter) are loaded at that moment, causing the import to fail
with ModuleNotFoundError.

Following the first recommendation from the 'Single-sourcing the
package version' section of the Python Package User Guide [1], in this
commit we switch to reading the version string from the '__init__.py'
file instead of attempting to import the module.

[1]: https://packaging.python.org/guides/single-sourcing-package-version/

---

Also includes updates in patch at
https://github.com/ppannuto/python-titlecase/pull/54#issuecomment-643048143