### PR TITLE
change `setup_requires` to `install_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,8 @@ setup(name='titlecase',
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    tests_require=['nose', 'regex'],
-    setup_requires=['nose>=1.0', 'regex>=2020.4.4'],
+    tests_require=['nose>=1.0', 'regex>=2020.4.4'],
+    install_requires=['regex>=2020.4.4'],
     test_suite="titlecase.tests",
     entry_points = {
         'console_scripts': [


### PR DESCRIPTION
Fixes #56.

--

@iburago, I think it makes sense to just move `nose` over too? Nothing is really done in setup for this package.