### PR TITLE
Look for the default abbreviations file in titlecase() only when called from command line

### DIFF
--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -64,12 +64,12 @@ def set_small_word_list(small=SMALL):
 
 def create_wordlist_filter(path_to_config=None):
     """
-    This function checks for a default list of abbreviations which need to 
-    remain as they are (e.g. uppercase only or mixed case).
-    The file is retrieved from ~/.titlecase.txt (platform independent)
+    This function reads the file with the given path to check for
+    a default list of abbreviations which need to remain as they are
+    (e.g. uppercase only or mixed case).
     """
     if path_to_config is None:
-        path_to_config = os.path.join(os.path.expanduser('~'), ".titlecase.txt")
+        return lambda word, **kwargs : None
     if not os.path.isfile(str(path_to_config)):
         logger.debug('No config file found at ' + str(path_to_config))
         return lambda word, **kwargs : None
@@ -249,5 +249,10 @@ def cmd():
         with ifile:
             in_string = ifile.read()
 
+    if args.wordlist is not None:
+        wordlist_file = args.wordlist
+    else:
+        wordlist_file = os.path.join(os.path.expanduser('~'), '.titlecase.txt')
+
     with ofile:
-        ofile.write(titlecase(in_string, wordlist_file=args.wordlist))
+        ofile.write(titlecase(in_string, wordlist_file=wordlist_file))


### PR DESCRIPTION
If the `titlecase()` function is called directly as a library routine,
no file system operations should be incurred, unless an effort
is made on the caller’s side in the form of passing a filename
via the `wordlist_file` argument.

Fixes #58. May be closed in favor of #60.