### PR TITLE
Do not capitalize small words occurring within hyphenated word groups

### DIFF
--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -129,7 +129,7 @@ def titlecase(text, callback=None, small_first_last=True):
 
             if '-' in word:
                 hyphenated = map(
-                    lambda t: titlecase(t, callback, small_first_last),
+                    lambda t: titlecase(t, callback, False),
                     word.split('-')
                 )
                 tc_line.append("-".join(hyphenated))

--- a/titlecase/tests.py
+++ b/titlecase/tests.py
@@ -32,6 +32,10 @@ TEST_DATA = (
         "Dance With Me/Let’s Face the Music and Dance"
     ),
     (
+        "a-b end-to-end two-not-three/three-by-four/five-and",
+        "A-B End-to-End Two-Not-Three/Three-by-Four/Five-And"
+    ),
+    (
         "34th 3rd 2nd",
         "34th 3rd 2nd"
     ),


### PR DESCRIPTION
Fixes #62.