### PR TITLE
Always capitalize 'Mc'-prefixed small words in compound word groups

### DIFF
--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -109,7 +109,7 @@ def titlecase(text, callback=None, small_first_last=True):
             match = MAC_MC.match(word)
             if match:
                 tc_line.append("%s%s" % (match.group(1).capitalize(),
-                                         titlecase(match.group(2), callback, small_first_last)))
+                                         titlecase(match.group(2), callback, True)))
                 continue
 
             if INLINE_PERIOD.search(word) or (not all_caps and UC_ELSEWHERE.match(word)):

--- a/titlecase/tests.py
+++ b/titlecase/tests.py
@@ -251,6 +251,14 @@ TEST_DATA = (
         "o'melveny/o'doyle o'Melveny/o'doyle O'melveny/o'doyle o'melveny/o'Doyle o'melveny/O'doyle",
         "O'Melveny/O'Doyle O'Melveny/O'Doyle O'Melveny/O'Doyle O'Melveny/O'Doyle O'Melveny/O'Doyle",
     ),
+    # These 'Mc' cases aim to ensure more consistent/predictable behavior.
+    # The examples here are somewhat contrived, and are subject to change
+    # if there is a compelling argument for updating their behavior.
+    # See https://github.com/ppannuto/python-titlecase/issues/64
+    (
+        "mccay-mcbut-mcdo mcdonalds/mcby",
+        "McCay-McBut-McDo McDonalds/McBy"
+    ),
     (
         "oblon, spivak, mcclelland, maier & neustadt",
         "Oblon, Spivak, McClelland, Maier & Neustadt",


### PR DESCRIPTION
Fixes #64.