### PR TITLE
Support re as an alternative to regex

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(name='titlecase',
     include_package_data=True,
     zip_safe=False,
     tests_require=['nose>=1.0', 'regex>=2020.4.4'],
-    install_requires=['regex>=2020.4.4'],
+    extra_requires=['regex>=2020.4.4'],
     test_suite="titlecase.tests",
     entry_points = {
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(name='titlecase',
     include_package_data=True,
     zip_safe=False,
     tests_require=['nose>=1.0', 'regex>=2020.4.4'],
-    extra_requires=['regex>=2020.4.4'],
+    extras_requires=['regex>=2020.4.4'],
     test_suite="titlecase.tests",
     entry_points = {
         'console_scripts': [
@@ -54,4 +54,3 @@ setup(name='titlecase',
             ],
         },
 )
-

--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -11,11 +11,13 @@ import argparse
 import logging
 logger = logging.getLogger(__name__)
 import os
-import re
 import string
 import sys
 
-import regex
+try:
+    import regex
+except ImportError:
+    import re as regex
 
 __all__ = ['titlecase']
 __version__ = '2.0.0'


### PR DESCRIPTION
Switch regex to an optional requirement in setup.py 
Fallback to re if it doesn't import