### PR TITLE
Fix invalid escape sequence warning

### DIFF
--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -167,7 +167,7 @@ def titlecase(text, callback=None, small_first_last=True, preserve_blank_lines=F
             # too short (like "St", don't apply this)
             CONSONANTS = ''.join(set(string.ascii_lowercase)
                                  - {'a', 'e', 'i', 'o', 'u', 'y'})
-            is_all_consonants = regex.search('\A[' + CONSONANTS + ']+\Z', word,
+            is_all_consonants = regex.search(r'\A[' + CONSONANTS + r']+\Z', word,
                                              flags=regex.IGNORECASE)
             if is_all_consonants and len(word) > 2:
                 tc_line.append(word.upper())


### PR DESCRIPTION
Summary: Python starts warning in 3.6+ about invalid escape sequences in strings. These regexes currently trigger that warning, but we can fix that easily by converting them to raw strings instead.

Test Plan: For each string changed, tested that '$str' == r'$str' in the python shell. ran tox and confirmed it still passed for py37, py38, py39 and py310