### PR TITLE
Add an option to preserve the input space characters

### DIFF
--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -77,16 +77,18 @@ def set_small_word_list(small=SMALL):
     SUBPHRASE = regex.compile(r'([:.;?!][ ])(%s)' % small)
 
 
-def titlecase(text, callback=None, small_first_last=True, preserve_blank_lines=False):
+def titlecase(text, callback=None, small_first_last=True, preserve_blank_lines=False, normalise_space_characters=False):
     """
     :param text: Titlecases input text
     :param callback: Callback function that returns the titlecase version of a specific word
     :param small_first_last: Capitalize small words (e.g. 'A') at the beginning; disabled when recursing
     :param preserve_blank_lines: Preserve blank lines in the output
+    :param normalise_space_characters: Convert all original spaces to normal space characters
     :type text: str
     :type callback: function
     :type small_first_last: bool
     :type preserve_blank_lines: bool
+    :type normalise_space_characters: bool
 
     This filter changes all words to Title Caps, and attempts to be clever
     about *un*capitalizing SMALL words like a/an/the in the input.
@@ -102,7 +104,9 @@ def titlecase(text, callback=None, small_first_last=True, preserve_blank_lines=F
     processed = []
     for line in lines:
         all_caps = line.upper() == line
-        words = regex.split('[\t ]', line)
+        split_line = regex.split(r'(\s)', line)
+        words = split_line[::2]
+        spaces = split_line[1::2]
         tc_line = []
         for word in words:
             if callback:
@@ -190,7 +194,13 @@ def titlecase(text, callback=None, small_first_last=True, preserve_blank_lines=F
                     lambda m: m.group(0).capitalize(), tc_line[-1]
                 )
 
-        result = " ".join(tc_line)
+        if normalise_space_characters:
+            result = " ".join(tc_line)
+        else:
+            line_to_be_joined = tc_line + spaces
+            line_to_be_joined[::2] = tc_line
+            line_to_be_joined[1::2] = spaces
+            result = "".join(line_to_be_joined)
 
         result = SUBPHRASE.sub(lambda m: '%s%s' % (
             m.group(1),

--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -82,9 +82,11 @@ def titlecase(text, callback=None, small_first_last=True, preserve_blank_lines=F
     :param text: Titlecases input text
     :param callback: Callback function that returns the titlecase version of a specific word
     :param small_first_last: Capitalize small words (e.g. 'A') at the beginning; disabled when recursing
+    :param preserve_blank_lines: Preserve blank lines in the output
     :type text: str
     :type callback: function
     :type small_first_last: bool
+    :type preserve_blank_lines: bool
 
     This filter changes all words to Title Caps, and attempts to be clever
     about *un*capitalizing SMALL words like a/an/the in the input.

--- a/titlecase/tests.py
+++ b/titlecase/tests.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../'))
 from titlecase import titlecase, set_small_word_list, create_wordlist_filter_from_file
 
 
-# (executed by `test_input_output` below)
+# (executed by `test_specific_string` below)
 TEST_DATA = (
     (
         "",

--- a/titlecase/tests.py
+++ b/titlecase/tests.py
@@ -307,6 +307,10 @@ TEST_DATA = (
         "Mr mr Mrs Ms Mss Dr dr , Mr. and Mrs. Person",
         "Mr Mr Mrs Ms MSS Dr Dr , Mr. And Mrs. Person",
     ),
+    (
+        "a mix of\tdifferent\u200aspace\u2006characters",
+        "A Mix of\tDifferent\u200aSpace\u2006Characters",
+    ),
 )
 
 
@@ -429,6 +433,16 @@ class TestBlankLines(unittest.TestCase):
         self.assertEqual(titlecase(s, preserve_blank_lines=True),
                 '\n\nLeading Blank\n\n\nMulti-Blank\n\n\n\n\nTrailing Blank\n\n')
 
+class TestNormaliseSpaceCharacters(unittest.TestCase):
+    def test_tabs(self):
+        s = 'text\twith\ttabs'
+        self.assertEqual(titlecase(s), 'Text\tWith\tTabs')
+        self.assertEqual(titlecase(s, normalise_space_characters=True), 'Text With Tabs')
+
+    def test_nbsps(self):
+        s = 'text with nonbreaking spaces'
+        self.assertEqual(titlecase(s), 'Text With Nonbreaking Spaces')
+        self.assertEqual(titlecase(s, normalise_space_characters=True), 'Text With Nonbreaking Spaces')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This potentially changes the output in two ways:

1. We now match (on line 107) any space character rather than just a tab or a space. The test case as it stands continues to pass, and the output remains separated by space characters.

2. There’s a new boolean parameter called `preserve_space_characters` that changes the output to use the space characters that were passed in. This is more accurate, but an obvious change to the existing behaviour hence the gating behind a default-`False` parameter.

I’ve also included a couple of commits here that tidy up comment mistakes found when I was initially going through the code.